### PR TITLE
Add license and introductory paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 Welcome to the Springer Nature SciGraph project.
 
-Please see the project homepage [https://www.springernature.com/scigraph](https://www.springernature.com/scigraph) for more information.
+SciGraph is the Springer Nature linked data platform that collates information from across the research landscape, i.e. the things, documents, people, places and relations of importance to the science and scholarly domain. 
+
+This GitHub repo is ancillary to the main SciGraph linked data portal. Please see the project homepage [https://www.springernature.com/scigraph](https://www.springernature.com/scigraph) for more information.
+
+## License
+
+The majority of SciGraph data is being made available under a [CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0/), i.e. attribution. A smaller portion of the data, however, employs a [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) license, i.e. attribution and non-commercial. This restricted subset specifically comprises book chapter and journal article abstracts, and grants. 
+
+More detailed information about licenses can be found on the [License page](https://scigraph.springernature.com/explorer/license/).
+
+You will receive a copy of the relevant license along with the data when you download a dataset from [the Scigraph Downloads page](https://scigraph.springernature.com/explorer/downloads/). 
 
 ----------
 


### PR DESCRIPTION
We're going to create an index of our open license repos in Github soon, and I want to include this 😄 

Since people may end up coming in from Github as a result, it'd be good for them to immediately see what the repo is about. I've copied in the license information from the Scigraph website, and the introduction from the github wiki. 